### PR TITLE
Add the active option :exact_with_params and :inclusive_with_params

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -59,9 +59,10 @@ defmodule PhoenixActiveLink do
     extra_class = extra_class(active?, opts)
     opts = append_class(opts, extra_class)
     link = make_link(active?, text, opts)
+
     cond do
       tag = opts[:wrap_tag] -> content_tag(tag, link, wrap_tag_opts(extra_class, opts))
-      true                  -> link
+      true -> link
     end
   end
 
@@ -90,6 +91,8 @@ defmodule PhoenixActiveLink do
     * a `{controller, action}` list - A list of tuples with a controller module and an action symbol.
 
         Both can be the `:any` symbol to match any controller or action.
+    * `:exact_with_params`     - Will return `true` if the current path and the link path are exactly the same,
+       including trailing slashes and query string as is.
 
   ## Examples
 
@@ -99,34 +102,61 @@ defmodule PhoenixActiveLink do
   active_path?(conn, to: "/foo", active: :exclusive)
   active_path?(conn, to: "/foo", active: ~r(^/foo/[0-9]+))
   active_path?(conn, to: "/foo", active: [{MyController, :index}, {OtherController, :any}])
+  active_path?(conn, to: "/foo?bar=baz%20foo", active: :exact_with_params)
   ```
 
   """
   def active_path?(conn, opts) do
     to = Keyword.get(opts, :to, "")
+
     case Keyword.get(opts, :active, :inclusive) do
-      true       -> true
-      false      -> false
-      :inclusive -> starts_with_path?(conn.request_path, to)
-      :exclusive -> String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
-      :exact     -> conn.request_path == to
-      %Regex{} = regex -> Regex.match?(regex, conn.request_path)
+      true ->
+        true
+
+      false ->
+        false
+
+      :inclusive ->
+        starts_with_path?(conn.request_path, to)
+
+      :exclusive ->
+        String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
+
+      :exact ->
+        conn.request_path == to
+
+      %Regex{} = regex ->
+        Regex.match?(regex, conn.request_path)
+
       controller_actions when is_list(controller_actions) ->
         controller_actions_active?(conn, controller_actions)
-      _ -> false
+
+      :exact_with_params ->
+        request_path_with_params(conn) == to
+
+      _ ->
+        false
     end
   end
 
   # NOTE: root path is an exception, otherwise it would be active all the time
   defp starts_with_path?(request_path, "/") when request_path != "/", do: false
+
   defp starts_with_path?(request_path, to) do
     String.starts_with?(request_path, String.trim_trailing(to, "/"))
   end
 
   defp controller_actions_active?(conn, controller_actions) do
-    Enum.any? controller_actions, fn {controller, action} ->
+    Enum.any?(controller_actions, fn {controller, action} ->
       (controller == :any or controller == conn.private.phoenix_controller) and
         (action == :any or action == conn.private.phoenix_action)
+    end)
+  end
+
+  defp request_path_with_params(conn) do
+    case conn.query_string do
+      "" -> conn.request_path
+      query_string -> conn.request_path <> "?" <> query_string
     end
   end
 
@@ -159,6 +189,7 @@ defmodule PhoenixActiveLink do
       |> List.insert_at(0, class)
       |> Enum.reject(&(&1 == ""))
       |> Enum.join(" ")
+
     Keyword.put(opts, :class, class)
   end
 

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -57,23 +57,42 @@ defmodule PhoenixActiveLinkTest do
 
   test "active_link without :wrap_tag" do
     assert active_link(conn(path: "/"), "Link", to: "/foo") == link("Link", to: "/foo", class: "")
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo") == link("Link", to: "/foo", class: "active")
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar") == link("Link", to: "/foo", class: "active bar")
-    link = active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar", class_active: "enabled")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo") ==
+             link("Link", to: "/foo", class: "active")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar") ==
+             link("Link", to: "/foo", class: "active bar")
+
+    link =
+      active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar", class_active: "enabled")
+
     assert link == link("Link", to: "/foo", class: "enabled bar")
-    link = active_link(conn(path: "/bar"), "Link", to: "/foo", class: "bar", class_inactive: "disabled")
+
+    link =
+      active_link(
+        conn(path: "/bar"),
+        "Link",
+        to: "/foo",
+        class: "bar",
+        class_inactive: "disabled"
+      )
+
     assert link == link("Link", to: "/foo", class: "disabled bar")
   end
 
   test "active_link with a block" do
     content = content_tag(:p, "Hello")
-    expected = link(to: "/foo", class: "") do
-      content
-    end
 
-    result = active_link(conn(path: "/"), to: "/foo") do
-       content
-    end
+    expected =
+      link to: "/foo", class: "" do
+        content
+      end
+
+    result =
+      active_link conn(path: "/"), to: "/foo" do
+        content
+      end
 
     assert result == expected
   end
@@ -82,18 +101,78 @@ defmodule PhoenixActiveLinkTest do
     expected = content_tag(:li, link("Link", to: "/foo", class: "active"), class: "active")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo", wrap_tag: :li) == expected
 
-    expected = content_tag(:li, link("Link", to: "/foo", class: "disabled"), class: "disabled foo")
-    link = active_link(conn(path: "/bar"), "Link", to: "/foo", class_inactive: "disabled", wrap_tag: :li, wrap_tag_opts: [class: "foo"])
+    expected =
+      content_tag(:li, link("Link", to: "/foo", class: "disabled"), class: "disabled foo")
+
+    link =
+      active_link(
+        conn(path: "/bar"),
+        "Link",
+        to: "/foo",
+        class_inactive: "disabled",
+        wrap_tag: :li,
+        wrap_tag_opts: [class: "foo"]
+      )
+
     assert link == expected
   end
 
+  test "active_link with :exact_with_params" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar=baz"),
+             "Link",
+             to: "/foo?bar=baz",
+             active: :exact_with_params,
+             class: "link"
+           ) == link("Link", to: "/foo?bar=baz", class: "active link")
+  end
+
+  test "active_link with :exact_with_params and special chars" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar[keyword]=baz+in+ga"),
+             "Link",
+             to: "/foo?bar[keyword]=baz+in+ga",
+             active: :exact_with_params,
+             class: "link"
+           ) == link("Link", to: "/foo?bar[keyword]=baz+in+ga", class: "active link")
+  end
+
+  test "active_link with :exact_with_params and special chars fails" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar[keyword]=baz%20in%20ga"),
+             "Link",
+             to: "/foo?bar[keyword]=baz+in+ga",
+             active: :exact_with_params
+           ) == link("Link", to: "/foo?bar[keyword]=baz+in+ga", class: "")
+  end
+
+  test "active_link with :exact_with_params without active class" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar=1&baz=2"),
+             "Link",
+             to: "/foo?baz=1&bar=2",
+             active: :exact_with_params
+           ) == link("Link", to: "/foo?baz=1&bar=2", class: "")
+  end
+
+  test "active_link with :exact_with_params same params in different order" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar=2&baz=1"),
+             "Link",
+             to: "/foo?baz=1&bar=2",
+             active: :exact_with_params
+           ) == link("Link", to: "/foo?baz=1&bar=2", class: "")
+  end
+
   test "customize defaults" do
-    Application.put_env(:phoenix_active_link, :defaults, [wrap_tag: :li])
+    Application.put_env(:phoenix_active_link, :defaults, wrap_tag: :li)
     expected = content_tag(:li, link("Link", to: "/foo", class: "active"), class: "active")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo") == expected
 
-    Application.put_env(:phoenix_active_link, :defaults, [class_active: "enabled"])
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo") == link("Link", to: "/foo", class: "enabled")
+    Application.put_env(:phoenix_active_link, :defaults, class_active: "enabled")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo") ==
+             link("Link", to: "/foo", class: "enabled")
   after
     Application.put_env(:phoenix_active_link, :defaults, [])
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,10 +5,10 @@ defmodule TestHelpers do
     %Plug.Conn{}
     |> Map.put(:private, make_private(opts))
     |> Map.put(:request_path, opts[:path])
+    |> Map.put(:query_string, opts[:query_string] || "")
   end
 
   defp make_private(opts) do
-    %{phoenix_controller: opts[:controller],
-      phoenix_action: opts[:action]}
+    %{phoenix_controller: opts[:controller], phoenix_action: opts[:action]}
   end
 end


### PR DESCRIPTION
- [ ] `active: :inclusive_with_params` this will check the same as `:inclusive` but also checks if the query_params of the `to`-link are present in the `conn.query_params`
- [x] `active: :exact_with_params` this will add the query string to the `request_path` and checks if the `to` and new `request path` are equal.
