### PR TITLE
Add the active option :inclusive_with_params

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -24,6 +24,10 @@ defmodule PhoenixActiveLink do
 
   use Phoenix.HTML
 
+  import Plug.Conn
+
+  alias Plug.Conn.Query
+
   @opts ~w(active wrap_tag class_active class_inactive active_disable wrap_tag_opts)a
 
   @doc """
@@ -59,9 +63,10 @@ defmodule PhoenixActiveLink do
     extra_class = extra_class(active?, opts)
     opts = append_class(opts, extra_class)
     link = make_link(active?, text, opts)
+
     cond do
       tag = opts[:wrap_tag] -> content_tag(tag, link, wrap_tag_opts(extra_class, opts))
-      true                  -> link
+      true -> link
     end
   end
 
@@ -90,7 +95,10 @@ defmodule PhoenixActiveLink do
     * a `{controller, action}` list - A list of tuples with a controller module and an action symbol.
 
         Both can be the `:any` symbol to match any controller or action.
+    * `:inclusive_with_params` - Will return `true` if the current path is equal to the link path and the query params of the current path are included to the link path.
 
+      For example, `active_path?(conn, to: "/foo?bar=2")` will return `true` if the path is `"/foo?bar=2"` or `"/foo?baz=2&bar=2"`.
+      For example, `active_path?(conn, to: "/foo?bar=2")` will return `false` if the path is `"/foobaz?bar=2"`.
   ## Examples
 
   ```elixir
@@ -99,36 +107,76 @@ defmodule PhoenixActiveLink do
   active_path?(conn, to: "/foo", active: :exclusive)
   active_path?(conn, to: "/foo", active: ~r(^/foo/[0-9]+))
   active_path?(conn, to: "/foo", active: [{MyController, :index}, {OtherController, :any}])
+  active_path?(conn, to: "/foo?baz=2", active: :inclusive_with_params)
   ```
 
   """
   def active_path?(conn, opts) do
     to = Keyword.get(opts, :to, "")
+
     case Keyword.get(opts, :active, :inclusive) do
-      true       -> true
-      false      -> false
-      :inclusive -> starts_with_path?(conn.request_path, to)
-      :exclusive -> String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
-      :exact     -> conn.request_path == to
-      %Regex{} = regex -> Regex.match?(regex, conn.request_path)
+      true ->
+        true
+
+      false ->
+        false
+
+      :inclusive ->
+        starts_with_path?(conn.request_path, to)
+
+      :exclusive ->
+        String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
+
+      :exact ->
+        conn.request_path == to
+
+      %Regex{} = regex ->
+        Regex.match?(regex, conn.request_path)
+
       controller_actions when is_list(controller_actions) ->
         controller_actions_active?(conn, controller_actions)
-      _ -> false
+
+      :inclusive_with_params ->
+        compare_path_and_params(conn, to)
+
+      _ ->
+        false
     end
   end
 
   # NOTE: root path is an exception, otherwise it would be active all the time
   defp starts_with_path?(request_path, "/") when request_path != "/", do: false
+
   defp starts_with_path?(request_path, to) do
     String.starts_with?(request_path, String.trim_trailing(to, "/"))
   end
 
   defp controller_actions_active?(conn, controller_actions) do
-    Enum.any? controller_actions, fn {controller, action} ->
+    Enum.any?(controller_actions, fn {controller, action} ->
       (controller == :any or controller == conn.private.phoenix_controller) and
         (action == :any or action == conn.private.phoenix_action)
+    end)
+  end
+
+  defp compare_path_and_params(conn, to) do
+    %{query_params: request_params} = fetch_query_params(conn)
+
+    with [path, query_params] <- String.split(to, "?"),
+         true <- conn.request_path == path do
+      decoded_params =
+        query_params
+        |> Query.decode()
+
+      map_include?(request_params, decoded_params)
+    else
+      [path] -> conn.request_path == path
+      false -> false
     end
   end
+
+  defp map_include?(map, {key, %{} = value}), do: map_include?(map[key], value)
+  defp map_include?(map, {key, value}), do: map[key] == value
+  defp map_include?(in_map, %{} = map), do: Enum.all?(map, &map_include?(in_map, &1))
 
   defp wrap_tag_opts(extra_class, opts) do
     Keyword.get(opts, :wrap_tag_opts, [])
@@ -159,6 +207,7 @@ defmodule PhoenixActiveLink do
       |> List.insert_at(0, class)
       |> Enum.reject(&(&1 == ""))
       |> Enum.join(" ")
+
     Keyword.put(opts, :class, class)
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,10 +5,10 @@ defmodule TestHelpers do
     %Plug.Conn{}
     |> Map.put(:private, make_private(opts))
     |> Map.put(:request_path, opts[:path])
+    |> Map.put(:query_string, opts[:query_string] || "")
   end
 
   defp make_private(opts) do
-    %{phoenix_controller: opts[:controller],
-      phoenix_action: opts[:action]}
+    %{phoenix_controller: opts[:controller], phoenix_action: opts[:action]}
   end
 end


### PR DESCRIPTION
This will check if the query params of the link path are included in the current path